### PR TITLE
(feature) Rudimentary colorised bork output

### DIFF
--- a/lib/declarations/ok.sh
+++ b/lib/declarations/ok.sh
@@ -17,7 +17,12 @@ _checking () {
 }
 _checked () {
   report="$*"
-  (( pad=$_checked_len - ${#report} ))
+
+  # We need to clear the current line with spaces so find out how wide the
+  # report is, and pad with the difference between that and the equivalent
+  # "checking" line.
+  # add in 10 extra chars of padding, to account for potential color codes
+  (( pad=$_checked_len - ${#report} + 10 ))
   i=1
   while [ "$i" -le $pad ]; do
     report+=" "

--- a/lib/helpers/status_codes.sh
+++ b/lib/helpers/status_codes.sh
@@ -14,24 +14,31 @@ STATUS_FAILED_ARGUMENT_PRECONDITION=32
 STATUS_FAILED_PRECONDITION=33
 STATUS_UNSUPPORTED_PLATFORM=34
 
+if [ ! -z "$BORK_COLOR" ]; then
+    GREEN="\e[92m"
+    RED="\e[91m"
+    YELLOW="\e[93m"
+    RESET="\e[39m"
+fi
+
 _status_for () {
   case "$1" in
-    $STATUS_OK) echo "ok" ;;
-    $STATUS_FAILED) echo "failed" ;;
-    $STATUS_MISSING) echo "missing" ;;
-    $STATUS_OUTDATED) echo "outdated" ;;
-    $STATUS_PARTIAL) echo "partial" ;;
-    $STATUS_MISMATCH_UPGRADE) echo "mismatch (upgradable)" ;;
-    $STATUS_MISMATCH_CLOBBER) echo "mismatch (clobber required)" ;;
-    $STATUS_CONFLICT_UPGRADE) echo "conflict (upgradable)" ;;
-    $STATUS_CONFLICT_CLOBBER) echo "conflict (clobber required)" ;;
-    $STATUS_CONFLICT_HALT) echo "conflict (unresolvable)" ;;
-    $STATUS_BAD_ARGUMENT) echo "error (bad arguments)" ;;
-    $STATUS_FAILED_ARGUMENTS) echo "error (failed arguments)" ;;
-    $STATUS_FAILED_ARGUMENT_PRECONDITION) echo "error (failed argument precondition)" ;;
-    $STATUS_FAILED_PRECONDITION) echo "error (failed precondition)" ;;
-    $STATUS_UNSUPPORTED_PLATFORM) echo "error (unsupported platform)" ;;
-    *)    echo "unknown status: $1" ;;
+    $STATUS_OK)                           echo -e "${GREEN}ok${RESET}" ;;
+    $STATUS_FAILED)                       echo -e "${RED}failed${RESET}" ;;
+    $STATUS_MISSING)                      echo -e "${RED}missing${RESET}" ;;
+    $STATUS_OUTDATED)                     echo -e "${YELLOW}outdated${RESET}" ;;
+    $STATUS_PARTIAL)                      echo -e "${YELLOW}partial${RESET}" ;;
+    $STATUS_MISMATCH_UPGRADE)             echo -e "${YELLOW}mismatch (upgradable)${RESET}" ;;
+    $STATUS_MISMATCH_CLOBBER)             echo -e "${RED}mismatch (clobber required)${RESET}" ;;
+    $STATUS_CONFLICT_UPGRADE)             echo -e "${YELLOW}conflict (upgradable)${RESET}" ;;
+    $STATUS_CONFLICT_CLOBBER)             echo -e "${RED}conflict (clobber required)${RESET}" ;;
+    $STATUS_CONFLICT_HALT)                echo -e "${RED}conflict (unresolvable)${RESET}" ;;
+    $STATUS_BAD_ARGUMENT)                 echo -e "${RED}error (bad arguments)${RESET}" ;;
+    $STATUS_FAILED_ARGUMENTS)             echo -e "${RED}error (failed arguments)${RESET}" ;;
+    $STATUS_FAILED_ARGUMENT_PRECONDITION) echo -e "${RED}error (failed argument precondition)${RESET}" ;;
+    $STATUS_FAILED_PRECONDITION)          echo -e "${RED}error (failed precondition)${RESET}" ;;
+    $STATUS_UNSUPPORTED_PLATFORM)         echo -e "${RED}error (unsupported platform)${RESET}" ;;
+    *)                                    echo -e "${RED}unknown status${RESET}: $1" ;;
   esac
 }
 


### PR DESCRIPTION
This is an initial attempt at https://github.com/skylarmacdonald/bork/issues/22

For now, this uses an environment variable to decide whether or not to colorise the output.
Works as a Proof of Concept, but ideally this would be a Bork flag.
i.e. `bork --color ...`

![image](https://user-images.githubusercontent.com/1116529/116784882-88ac4000-aa8e-11eb-911c-f663267779ff.png)

In my [borkify](https://github.com/lucymhdavies/dev_utils/blob/main/bin/borkify) script...
![image](https://user-images.githubusercontent.com/1116529/116785074-8991a180-aa8f-11eb-8d00-6ebd1ca0c4d8.png)
