### PR TITLE
(feature) (types) git: allow user to specify whether or not to check for untracked files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Changes here will be in the next release. You can use them now by checking out t
 - `bork types` now supports a single type as an argument to get documentation for that specific type only.
 - `bork inspect` will generate a Bork-compatible config file based on the current status of the system. This is currently available on a per-type basis only, and will only be implemented for some types. (#14)
 - Bork will now report its version by running `bork --version` (or `bork version`).
+- The `git` type can now show untracked files, using the `--untracked-files` option. It responds to the same values as the `--untracked-files` option on git: `no` (default, ignore them), `normal` or `all`.
 
 ## [0.12.0] - 2021-02-20
 

--- a/docs/_types/git.md
+++ b/docs/_types/git.md
@@ -10,4 +10,5 @@ asserts presence and state of a git repository
 > git git@github.com:skylarmacdonald/bork
 > git ~/code/bork git@github.com:skylarmacdonald/bork
 --branch=gh-pages             (specify branch, tag, or ref)
+--untracked-files=normal      (specify what to do with untracked files. default is to ignore)
 ```

--- a/test/type-git.bats
+++ b/test/type-git.bats
@@ -85,6 +85,13 @@ git_status_handler ()   { echo "$git_status"; }
   [ "$status" -eq $STATUS_OUTDATED ]
 }
 
+@test "git status: returns CONFLICT_HALT when local git repository has untracked files" {
+  git_status=$(echo "## master"; echo "?? foo/bin/")
+  run git status git@github.com:skylarmacdonald/bork --untracked-files=normal
+  [ "$status" -eq $STATUS_CONFLICT_HALT ]
+  echo "$output" | grep -E 'untracked'
+}
+
 @test "git status: returns OK when the git repository is up-to-date" {
   git_status="## master"
   run git status git@github.com:skylarmacdonald/bork

--- a/test/type-git.bats
+++ b/test/type-git.bats
@@ -10,7 +10,8 @@ git_status=
 setup () {
   respond_to "[ ! -d bork ]"           "dir_exists_handler"
   respond_to "ls -A bork"              "dir_listing_handler"
-  respond_to "git status -uno -b --porcelain" "git_status_handler"
+  respond_to "git status --untracked-files=no -b --porcelain" "git_status_handler"
+  respond_to "git status --untracked-files=normal -b --porcelain" "git_status_handler"
 }
 dir_exists_handler ()   { [ "$dir_exists" -eq 0 ]; }
 dir_listing_handler ()  { echo "$dir_listing"; }


### PR DESCRIPTION
Example output from bork status:
```
conflict (unresolvable): github /Users/lucy.davinhart/git_src/dev_utils_private lucymhdavies/dev_utils_private --branch=main --ssh --untracked-files=normal
local git repository has untracked files
```

Fixes https://github.com/skylarmacdonald/bork/issues/27
